### PR TITLE
Feature/add appgw containers demo

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,3 +16,9 @@
 - Ensure shell scripts use `set -e` for strict error handling.
 - Test scripts and templates locally before committing when possible.
 - Use consistent indentation (spaces, not tabs) across all file types.
+
+## AKS Conventions
+
+- Always specify a **readable, custom node resource group name** instead of relying on AKS defaults (e.g., `MC_<rg>_<cluster>_<region>`).
+- Use the `nodeResourceGroup` property in Bicep or the `--node-resource-group` flag in Azure CLI.
+- Follow the naming pattern: `rg-<project>-<env>-nodes` (e.g., `rg-agfc-demo-dev-nodes`).

--- a/AKS-Advanced-Container-Networking/main.bicep
+++ b/AKS-Advanced-Container-Networking/main.bicep
@@ -223,6 +223,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2025-01-01' = {
   }
   properties: {
     dnsPrefix: dnsPrefix
+    nodeResourceGroup: 'rg-${clusterName}-nodes'
     kubernetesVersion: kubernetesVersion
     enableRBAC: true
     azureMonitorProfile: {

--- a/AKS-AppGW-Containers/README.md
+++ b/AKS-AppGW-Containers/README.md
@@ -1,0 +1,256 @@
+# AKS with Application Gateway for Containers (Gateway API)
+
+Deploy an AKS cluster using **Application Gateway for Containers** — the next generation of Azure Application Gateway designed for Kubernetes workloads. This demo uses the **Gateway API** (the successor to Ingress) with the ALB Controller AKS add-on.
+
+Two deployment strategies are supported:
+
+| Strategy | Description |
+|----------|-------------|
+| **Managed by ALB Controller** | ALB Controller creates and manages AGFC lifecycle via the `ApplicationLoadBalancer` CRD |
+| **Bring Your Own (BYO)** | AGFC resource, frontend, and association are pre-created in Azure (Bicep). The Gateway references them by resource ID |
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Azure Resource Group                                            │
+│                                                                  │
+│  ┌────────────────────────────────────────────────────────────┐  │
+│  │  Virtual Network (10.0.0.0/8)                              │  │
+│  │                                                            │  │
+│  │  ┌──────────────────────────────┐  ┌────────────────────┐  │  │
+│  │  │  AKS Subnet (10.224.0.0/16) │  │ ALB Subnet         │  │  │
+│  │  │                              │  │ (10.225.0.0/24)    │  │  │
+│  │  │  ┌────────────────────────┐  │  │ Delegated to       │  │  │
+│  │  │  │  AKS Cluster           │  │  │ Microsoft.Service  │  │  │
+│  │  │  │  (Azure CNI Overlay)   │  │  │  Networking/       │  │  │
+│  │  │  │                        │  │  │  trafficControllers│  │  │
+│  │  │  │  ┌──────────────────┐  │  │  │                    │  │  │
+│  │  │  │  │  ALB Controller  │  │  │  │  ┌──────────────┐  │  │  │
+│  │  │  │  │  (AKS Add-on)   │◄─┼──┼──┼──┤  App Gateway │  │  │  │
+│  │  │  │  └──────────────────┘  │  │  │  │  for         │  │  │  │
+│  │  │  │                        │  │  │  │  Containers  │  │  │  │
+│  │  │  │  ┌─────────┐          │  │  │  └──────┬───────┘  │  │  │
+│  │  │  │  │ Gateway │          │  │  │         │          │  │  │
+│  │  │  │  │   API   │          │  │  │    Internet        │  │  │
+│  │  │  │  │Resources│          │  │  │                    │  │  │
+│  │  │  │  └─────────┘          │  │  └────────────────────┘  │  │
+│  │  │  │                        │  │                          │  │
+│  │  │  │  ┌───────┐ ┌───────┐  │  │                          │  │
+│  │  │  │  │ v1    │ │ v2    │  │  │                          │  │
+│  │  │  │  │ Pods  │ │ Pods  │  │  │                          │  │
+│  │  │  │  └───────┘ └───────┘  │  │                          │  │
+│  │  │  └────────────────────────┘  │                          │  │
+│  │  └──────────────────────────────┘                          │  │
+│  └────────────────────────────────────────────────────────────┘  │
+│                                                                  │
+│  ┌──────────────────────┐                                        │
+│  │  Log Analytics       │                                        │
+│  │  + Container Insights│                                        │
+│  └──────────────────────┘                                        │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## What is Application Gateway for Containers?
+
+**Application Gateway for Containers** is a new application load balancing and dynamic traffic management product for workloads running in Kubernetes. It extends the Azure Application Gateway portfolio and is a new offering under the Application Gateway product family.
+
+Key advantages over the traditional AGIC (Application Gateway Ingress Controller):
+
+- **Gateway API support** — Uses the Kubernetes Gateway API standard (successor to Ingress)
+- **Near real-time convergence** — Configuration changes reflect in ~5 seconds (vs. minutes with AGIC)
+- **Traffic splitting** — Native weighted traffic splitting for blue-green and canary deployments
+- **Mutual authentication (mTLS)** — Support for client-side and backend mTLS
+- **No subnet reservation issues** — Uses a separate delegated subnet, no shared subnet complications
+- **Multi-site hosting** — Host multiple sites on a single Gateway resource
+
+## Prerequisites
+
+- Azure CLI with `alb` and `aks-preview` extensions
+- `kubectl`
+- An Azure subscription in a [supported region](https://learn.microsoft.com/azure/application-gateway/for-containers/overview#supported-regions)
+
+## Deployment Strategies
+
+### Option 1 — ALB Controller Managed (default)
+
+The ALB Controller manages the full AGFC lifecycle. An `ApplicationLoadBalancer` CRD is deployed into the cluster, and the controller creates the Azure resources automatically.
+
+```bash
+chmod +x deploy.sh
+./deploy.sh managed
+```
+
+### Option 2 — Bring Your Own (BYO)
+
+AGFC resources (traffic controller, frontend, association) are pre-created in Azure via Bicep. The Kubernetes Gateway resource references the existing AGFC by its Azure resource ID.
+
+```bash
+chmod +x deploy.sh
+./deploy.sh byo
+```
+
+## Test the Application
+
+Once deployed, get the gateway FQDN and test routing:
+
+```bash
+# Get the FQDN
+FQDN=$(kubectl get gateway gateway-01 -n test-infra -o jsonpath='{.status.addresses[0].value}')
+
+# Default route -> backend-v1
+curl http://$FQDN/
+
+# Path-based routing: /bar -> backend-v2
+curl http://$FQDN/bar
+
+# Header + query + path routing -> backend-v2
+curl http://$FQDN/some/thing?great=example -H "magic: foo"
+```
+
+## Clean Up
+
+```bash
+chmod +x cleanup.sh
+./cleanup.sh
+```
+
+## Project Structure
+
+```
+AKS-AppGW-Containers/
+├── main.bicep                                # Main Bicep orchestrator (strategy param)
+├── main.bicepparam                           # Parameters file
+├── deploy.sh                                 # Deployment script (managed | byo)
+├── cleanup.sh                                # Resource cleanup script
+├── README.md
+├── modules/
+│   ├── aks.bicep                             # AKS cluster (CNI Overlay + OIDC + WI)
+│   ├── vnet.bicep                            # VNet with delegated ALB subnet
+│   ├── agfc.bicep                            # AGFC resources (BYO strategy only)
+│   └── log-analytics.bicep                   # Log Analytics workspace
+└── kubernetes-manifests/
+    ├── 01-sample-apps.yaml                   # Backend v1 and v2 (shared)
+    ├── gateway-managed/
+    │   ├── 02-gateway.yaml                   # Gateway with ALB managed annotations
+    │   └── 03-httproute.yaml                 # Path + header routing
+    └── gateway-byo/
+        ├── 02-gateway.yaml                   # Gateway with alb-id + frontend address
+        └── 03-httproute.yaml                 # Path + header routing
+```
+
+## How the Two Strategies Differ
+
+### ALB Managed
+
+1. Bicep deploys VNet, AKS, and Log Analytics (no AGFC Azure resources).
+2. The deploy script creates an `ApplicationLoadBalancer` CRD in the cluster.
+3. ALB Controller provisions the AGFC traffic controller in the MC resource group.
+4. The Gateway annotation references the CRD by namespace/name:
+   ```yaml
+   annotations:
+     alb.networking.azure.io/alb-namespace: alb-test-infra
+     alb.networking.azure.io/alb-name: alb-test
+   ```
+
+### BYO (Bring Your Own)
+
+1. Bicep deploys VNet, AKS, Log Analytics **and** the AGFC traffic controller, frontend, and association.
+2. No `ApplicationLoadBalancer` CRD is needed.
+3. The Gateway annotation references the AGFC by its Azure resource ID:
+   ```yaml
+   annotations:
+     alb.networking.azure.io/alb-id: /subscriptions/.../trafficControllers/my-agfc
+   spec:
+     addresses:
+       - type: alb.networking.azure.io/alb-frontend
+         value: frontend
+   ```
+
+## Gateway API Resources Explained
+
+### GatewayClass
+
+The `azure-alb-external` GatewayClass is automatically installed by the ALB Controller add-on. It tells Kubernetes that Gateway resources referencing this class are managed by the Application Gateway for Containers.
+
+### Gateway
+
+The Gateway resource creates a listener on Application Gateway for Containers. The annotations differ depending on the deployment strategy (see above).
+
+### HTTPRoute
+
+HTTPRoutes define how traffic is routed from the Gateway to backend services. This demo includes:
+
+| Rule | Match | Backend |
+|------|-------|---------|
+| Path-based | `/bar` prefix | backend-v2 |
+| Header + query + path | header `magic: foo`, query `great=example`, path `/some/thing` | backend-v2 |
+| Default | everything else | backend-v1 |
+
+## Deployment Details
+
+### Infrastructure (Bicep)
+
+| Resource | Description |
+|----------|-------------|
+| **VNet** | Two subnets — AKS nodes (`10.224.0.0/16`) and ALB association (`10.225.0.0/24`) |
+| **AKS Cluster** | Azure CNI Overlay, OIDC Issuer, Workload Identity enabled |
+| **Log Analytics** | Container Insights monitoring |
+| **AGFC** *(BYO only)* | Traffic controller, frontend, and subnet association |
+
+The ALB subnet is delegated to `Microsoft.ServiceNetworking/trafficControllers`, which is required for Application Gateway for Containers.
+
+### AKS Add-on
+
+The deploy script enables two AKS add-ons:
+- `--enable-gateway-api` — Installs Gateway API CRDs
+- `--enable-application-load-balancer` — Installs ALB Controller
+
+This is the recommended approach over Helm-based deployment for managed environments.
+
+### Role Assignments
+
+Both strategies require these role assignments for the ALB managed identity:
+
+| Role | Scope | GUID |
+|------|-------|------|
+| AppGW for Containers Configuration Manager | Resource group (BYO) or MC resource group (managed) | `fbc52c3f-28ad-4303-a892-8a056630b8f1` |
+| Network Contributor | ALB subnet | `4d97b98b-1d4f-4787-a291-c67834d212e7` |
+
+## Troubleshooting
+
+### ALB Controller pods not running
+
+```bash
+kubectl get pods -n kube-system | grep alb-controller
+```
+
+### GatewayClass not found
+
+```bash
+kubectl get gatewayclass
+# Should show: azure-alb-external
+```
+
+### Gateway not getting an address
+
+```bash
+kubectl get gateway gateway-01 -n test-infra -o yaml
+# Check the status.conditions for errors
+```
+
+### ApplicationLoadBalancer stuck in InProgress
+
+```bash
+kubectl get applicationloadbalancer alb-test -n alb-test-infra -o yaml
+# Can take 5-6 minutes — check conditions for details
+```
+
+## References
+
+- [Application Gateway for Containers Overview](https://learn.microsoft.com/azure/application-gateway/for-containers/overview)
+- [Quickstart: Deploy ALB Controller (AKS Add-on)](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon)
+- [Create AGFC — Managed by ALB Controller](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-create-application-gateway-for-containers-managed-by-alb-controller)
+- [Create AGFC — Bring Your Own Deployment](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-create-application-gateway-for-containers-byo-deployment)
+- [Path, Header & Query String Routing](https://learn.microsoft.com/azure/application-gateway/for-containers/how-to-path-header-query-string-routing-gateway-api)
+- [Kubernetes Gateway API Spec](https://gateway-api.sigs.k8s.io/)

--- a/AKS-AppGW-Containers/README.md
+++ b/AKS-AppGW-Containers/README.md
@@ -217,6 +217,22 @@ Both strategies require these role assignments for the ALB managed identity:
 | AppGW for Containers Configuration Manager | Resource group (BYO) or MC resource group (managed) | `fbc52c3f-28ad-4303-a892-8a056630b8f1` |
 | Network Contributor | ALB subnet | `4d97b98b-1d4f-4787-a291-c67834d212e7` |
 
+## Important Limitations
+
+> **Note:** Application Gateway for Containers is evolving rapidly. Review the [official documentation](https://learn.microsoft.com/azure/application-gateway/for-containers/overview) for the latest status.
+
+| Limitation | Details |
+|------------|---------|
+| **Listener ports restricted to 80 and 443** | Gateway listeners only support port 80 (HTTP) and port 443 (HTTPS). Custom ports are not allowed. |
+| **Associations limited to 1** | Each AGFC resource currently supports only **one** association (one subnet). Multiple associations are planned but not yet available. |
+| **Private IP addresses not supported** | Frontends only expose a public FQDN. Private IP (internal-only) frontends are not currently supported. |
+| **Subnet requires /24 or larger** | The ALB association subnet must have at least 256 available addresses. If sharing the subnet across multiple AGFC resources, calculate as `n × 256`. |
+| **Backend communication is HTTP/1.1** | AGFC communicates with backends over HTTP/1.1 only (except gRPC, which uses HTTP/2). Client-to-frontend always supports HTTP/2. |
+| **60-second default request timeout** | The request timeout is 60 seconds by default. Long-running downloads or streaming may fail unless the timeout is increased. |
+| **Regional availability** | AGFC is available in a [subset of Azure regions](https://learn.microsoft.com/azure/application-gateway/for-containers/overview#supported-regions) only. |
+| **ReferenceGrant** | Only `v1alpha1` of the Gateway API `ReferenceGrant` resource is supported. |
+| **Frontends cannot be shared** | A frontend belongs exclusively to one AGFC resource and cannot be shared across multiple AGFC instances. |
+
 ## Troubleshooting
 
 ### ALB Controller pods not running

--- a/AKS-AppGW-Containers/README.md
+++ b/AKS-AppGW-Containers/README.md
@@ -108,6 +108,80 @@ curl http://$FQDN/bar
 curl http://$FQDN/some/thing?great=example -H "magic: foo"
 ```
 
+## Additional Gateway API Examples
+
+The following examples build on the base deployment and demonstrate advanced AGFC features.
+
+### Example 1 — Traffic Splitting / Weighted Round Robin
+
+Split traffic across backends using weighted routing. Useful for canary and blue-green deployments.
+
+```bash
+# Apply the traffic-splitting HTTPRoute (uses existing gateway-01)
+# Managed strategy
+kubectl apply -f kubernetes-manifests/gateway-managed/04-traffic-splitting.yaml
+
+# BYO strategy
+kubectl apply -f kubernetes-manifests/gateway-byo/04-traffic-splitting.yaml
+
+# Test — expect ~80% backend-v1, ~20% backend-v2
+watch -n 1 curl http://$FQDN
+```
+
+> **Tip:** Edit the `weight` values in the HTTPRoute to shift traffic. Set backend-v2 to `100` and backend-v1 to `0` for a full cutover.
+
+### Example 2 — SSL/TLS Offloading
+
+Gateway terminates TLS on port 443 and forwards plain HTTP to backends.
+
+```bash
+# 1. Generate the listener TLS secret
+chmod +x kubernetes-manifests/generate-tls-certs.sh
+./kubernetes-manifests/generate-tls-certs.sh ssl-offloading
+
+# 2. Deploy the HTTPS gateway + route
+# Managed strategy
+kubectl apply -f kubernetes-manifests/gateway-managed/05-ssl-offloading.yaml
+
+# BYO strategy (requires envsubst)
+envsubst < kubernetes-manifests/gateway-byo/05-ssl-offloading.yaml | kubectl apply -f -
+
+# 3. Wait for the gateway to get an address
+kubectl get gateway gateway-02-ssl -n test-infra -w
+
+# 4. Test
+SSL_FQDN=$(kubectl get gateway gateway-02-ssl -n test-infra -o jsonpath='{.status.addresses[0].value}')
+curl --insecure https://$SSL_FQDN/
+```
+
+### Example 3 — Backend mTLS
+
+End-to-end encryption with mutual TLS. AGFC terminates the client TLS connection, then establishes a new mTLS connection to the backend — presenting a client certificate for authentication.
+
+```bash
+# 1. Generate all mTLS certificates (CA, frontend, backend, client)
+chmod +x kubernetes-manifests/generate-tls-certs.sh
+./kubernetes-manifests/generate-tls-certs.sh backend-mtls
+
+# 2. Deploy the mTLS nginx backend app
+kubectl apply -f kubernetes-manifests/02-backend-mtls-app.yaml
+
+# 3. Deploy the HTTPS gateway + route + BackendTLSPolicy
+# Managed strategy
+kubectl apply -f kubernetes-manifests/gateway-managed/06-backend-mtls.yaml
+
+# BYO strategy (requires envsubst)
+envsubst < kubernetes-manifests/gateway-byo/06-backend-mtls.yaml | kubectl apply -f -
+
+# 4. Wait for the gateway and verify the BackendTLSPolicy
+kubectl get gateway gateway-03-mtls -n test-infra -w
+kubectl get backendtlspolicy mtls-app-tls-policy -n test-infra -o yaml
+
+# 5. Test
+MTLS_FQDN=$(kubectl get gateway gateway-03-mtls -n test-infra -o jsonpath='{.status.addresses[0].value}')
+curl --insecure https://$MTLS_FQDN/
+```
+
 ## Clean Up
 
 ```bash
@@ -131,12 +205,20 @@ AKS-AppGW-Containers/
 │   └── log-analytics.bicep                   # Log Analytics workspace
 └── kubernetes-manifests/
     ├── 01-sample-apps.yaml                   # Backend v1 and v2 (shared)
+    ├── 02-backend-mtls-app.yaml              # mTLS nginx backend (for example 3)
+    ├── generate-tls-certs.sh                 # Generate TLS certs for examples 2 & 3
     ├── gateway-managed/
     │   ├── 02-gateway.yaml                   # Gateway with ALB managed annotations
-    │   └── 03-httproute.yaml                 # Path + header routing
+    │   ├── 03-httproute.yaml                 # Path + header routing
+    │   ├── 04-traffic-splitting.yaml         # Weighted round robin (80/20)
+    │   ├── 05-ssl-offloading.yaml            # HTTPS Gateway + TLS termination
+    │   └── 06-backend-mtls.yaml              # HTTPS Gateway + BackendTLSPolicy
     └── gateway-byo/
         ├── 02-gateway.yaml                   # Gateway with alb-id + frontend address
-        └── 03-httproute.yaml                 # Path + header routing
+        ├── 03-httproute.yaml                 # Path + header routing
+        ├── 04-traffic-splitting.yaml         # Weighted round robin (80/20)
+        ├── 05-ssl-offloading.yaml            # HTTPS Gateway + TLS termination (BYO)
+        └── 06-backend-mtls.yaml              # HTTPS Gateway + BackendTLSPolicy (BYO)
 ```
 
 ## How the Two Strategies Differ
@@ -181,11 +263,18 @@ The Gateway resource creates a listener on Application Gateway for Containers. T
 
 HTTPRoutes define how traffic is routed from the Gateway to backend services. This demo includes:
 
-| Rule | Match | Backend |
-|------|-------|---------|
+| Route | Match | Backend |
+|-------|-------|---------|
 | Path-based | `/bar` prefix | backend-v2 |
 | Header + query + path | header `magic: foo`, query `great=example`, path `/some/thing` | backend-v2 |
 | Default | everything else | backend-v1 |
+| Traffic split | all traffic (weighted) | 80% backend-v1, 20% backend-v2 |
+| SSL offloading | HTTPS on port 443 → HTTP backend | backend-v1 |
+| Backend mTLS | HTTPS → mTLS to backend | mtls-app (nginx with client cert verification) |
+
+### BackendTLSPolicy
+
+The `BackendTLSPolicy` CRD (API group `alb.networking.azure.io/v1`) configures mTLS between AGFC and backend services. It specifies the client certificate AGFC presents, the CA bundle to verify the backend, and the expected SNI/SAN.
 
 ## Deployment Details
 
@@ -269,4 +358,7 @@ kubectl get applicationloadbalancer alb-test -n alb-test-infra -o yaml
 - [Create AGFC — Managed by ALB Controller](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-create-application-gateway-for-containers-managed-by-alb-controller)
 - [Create AGFC — Bring Your Own Deployment](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-create-application-gateway-for-containers-byo-deployment)
 - [Path, Header & Query String Routing](https://learn.microsoft.com/azure/application-gateway/for-containers/how-to-path-header-query-string-routing-gateway-api)
+- [Traffic Splitting (Weighted Round Robin)](https://learn.microsoft.com/azure/application-gateway/for-containers/how-to-traffic-splitting-gateway-api)
+- [SSL/TLS Offloading](https://learn.microsoft.com/azure/application-gateway/for-containers/how-to-ssl-offloading-gateway-api)
+- [Backend mTLS](https://learn.microsoft.com/azure/application-gateway/for-containers/how-to-backend-mtls-gateway-api)
 - [Kubernetes Gateway API Spec](https://gateway-api.sigs.k8s.io/)

--- a/AKS-AppGW-Containers/cleanup.sh
+++ b/AKS-AppGW-Containers/cleanup.sh
@@ -2,7 +2,7 @@
 
 # Cleanup script for AKS with Application Gateway for Containers Demo
 
-set -e
+set -euo pipefail
 
 # Colors for output
 RED='\033[0;31m'

--- a/AKS-AppGW-Containers/cleanup.sh
+++ b/AKS-AppGW-Containers/cleanup.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Cleanup script for AKS with Application Gateway for Containers Demo
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+RESOURCE_GROUP_NAME="rg-agfc-demo"
+
+print_message() {
+    echo -e "${GREEN}==>${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}WARNING:${NC} $1"
+}
+
+echo ""
+echo "=========================================="
+echo "   AKS + AppGW for Containers - Cleanup"
+echo "=========================================="
+echo ""
+
+print_warning "This will delete ALL resources in resource group: $RESOURCE_GROUP_NAME"
+echo ""
+
+read -p "Are you sure you want to continue? (y/N): " confirm
+if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+    echo "Cleanup cancelled."
+    exit 0
+fi
+
+# Delete Kubernetes resources first (if cluster is still accessible)
+print_message "Cleaning up Kubernetes resources..."
+kubectl delete -f kubernetes-manifests/gateway-managed/ 2>/dev/null || true
+kubectl delete -f kubernetes-manifests/gateway-byo/ 2>/dev/null || true
+kubectl delete -f kubernetes-manifests/01-sample-apps.yaml 2>/dev/null || true
+kubectl delete applicationloadbalancer alb-test -n alb-test-infra 2>/dev/null || true
+kubectl delete namespace alb-test-infra 2>/dev/null || true
+kubectl delete namespace test-infra 2>/dev/null || true
+
+print_message "Waiting for ALB resources to be cleaned up..."
+sleep 30
+
+# Delete the resource group
+print_message "Deleting resource group: ${RESOURCE_GROUP_NAME}..."
+az group delete --name "${RESOURCE_GROUP_NAME}" --yes --no-wait
+
+print_message "Cleanup initiated. Resource group deletion is running in the background."
+echo ""
+echo "Run the following command to check deletion status:"
+echo "  az group show --name ${RESOURCE_GROUP_NAME} --query 'properties.provisioningState' -o tsv"
+echo ""

--- a/AKS-AppGW-Containers/deploy.sh
+++ b/AKS-AppGW-Containers/deploy.sh
@@ -10,7 +10,7 @@
 #   ./deploy.sh managed      # Deploys with 'managed' strategy
 #   ./deploy.sh byo          # Deploys with 'byo' strategy
 
-set -e
+set -euo pipefail
 
 # Colors for output
 RED='\033[0;31m'
@@ -71,6 +71,11 @@ check_prerequisites() {
         exit 1
     fi
 
+    if [[ "$DEPLOYMENT_STRATEGY" == "byo" ]] && ! command -v envsubst &> /dev/null; then
+        print_error "envsubst is required for the 'byo' deployment strategy. Please install it first."
+        exit 1
+    fi
+
     print_message "All prerequisites met."
 }
 
@@ -87,8 +92,26 @@ register_providers() {
     az feature register --namespace "Microsoft.ContainerService" --name "ApplicationLoadBalancerPreview" 2>/dev/null || true
 
     print_info "Waiting for feature registration (this may take a few minutes)..."
-    az feature show --namespace "Microsoft.ContainerService" --name "ManagedGatewayAPIPreview" --query "properties.state" -o tsv 2>/dev/null || true
-    az feature show --namespace "Microsoft.ContainerService" --name "ApplicationLoadBalancerPreview" --query "properties.state" -o tsv 2>/dev/null || true
+    local features=("ManagedGatewayAPIPreview" "ApplicationLoadBalancerPreview")
+    local timeout=1800
+    local interval=30
+    for feature in "${features[@]}"; do
+        local elapsed=0
+        while true; do
+            local state
+            state=$(az feature show --namespace "Microsoft.ContainerService" --name "$feature" --query "properties.state" -o tsv 2>/dev/null || echo "Unknown")
+            print_info "Feature '$feature' state: $state"
+            if [[ "$state" == "Registered" ]]; then
+                break
+            fi
+            if [[ $elapsed -ge $timeout ]]; then
+                print_warning "Timed out waiting for feature '$feature' to register. Current state: $state. Continuing anyway..."
+                break
+            fi
+            sleep $interval
+            elapsed=$((elapsed + interval))
+        done
+    done
 
     az extension add --name alb --upgrade 2>/dev/null || true
     az extension add --name aks-preview --upgrade 2>/dev/null || true

--- a/AKS-AppGW-Containers/deploy.sh
+++ b/AKS-AppGW-Containers/deploy.sh
@@ -286,8 +286,11 @@ deploy_sample_apps() {
 
 deploy_gateway_managed() {
     print_message "Deploying Gateway and HTTPRoutes (ALB managed strategy)..."
-    kubectl apply -f kubernetes-manifests/gateway-managed/
+    kubectl apply -f kubernetes-manifests/gateway-managed/02-gateway.yaml
+    kubectl apply -f kubernetes-manifests/gateway-managed/03-httproute.yaml
     print_message "Gateway API resources deployed (ALB managed)."
+    print_info "Additional examples (traffic splitting, SSL offloading, backend mTLS) can be deployed separately."
+    print_info "See README.md for instructions."
 }
 
 deploy_gateway_byo() {

--- a/AKS-AppGW-Containers/deploy.sh
+++ b/AKS-AppGW-Containers/deploy.sh
@@ -1,0 +1,385 @@
+#!/bin/bash
+
+# Deployment script for AKS with Application Gateway for Containers
+# Supports two deployment strategies:
+#   - managed : ALB Controller manages AGFC lifecycle via ApplicationLoadBalancer CRD
+#   - byo     : Bring Your Own — AGFC resource pre-created in Azure via Bicep
+#
+# Usage:
+#   ./deploy.sh              # Deploys with 'managed' strategy (default)
+#   ./deploy.sh managed      # Deploys with 'managed' strategy
+#   ./deploy.sh byo          # Deploys with 'byo' strategy
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Variables
+DEPLOYMENT_STRATEGY="${1:-managed}"
+RESOURCE_GROUP_NAME="rg-agfc-demo"
+LOCATION="northeurope"
+DEPLOYMENT_NAME="agfc-deployment-$(date +%Y%m%d-%H%M%S)"
+AKS_NAME="agfc-aks-dev"
+ALB_SUBNET_NAME="subnet-alb"
+VNET_NAME="agfc-vnet-dev"
+AGFC_NAME="agfc-agfc-dev"
+
+# Validate strategy
+if [[ "$DEPLOYMENT_STRATEGY" != "managed" && "$DEPLOYMENT_STRATEGY" != "byo" ]]; then
+    echo -e "${RED}ERROR:${NC} Invalid deployment strategy: $DEPLOYMENT_STRATEGY"
+    echo "Usage: $0 [managed|byo]"
+    exit 1
+fi
+
+# Functions
+print_message() {
+    echo -e "${GREEN}==>${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}ERROR:${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}WARNING:${NC} $1"
+}
+
+print_info() {
+    echo -e "${BLUE}INFO:${NC} $1"
+}
+
+check_prerequisites() {
+    print_message "Checking prerequisites..."
+
+    if ! command -v az &> /dev/null; then
+        print_error "Azure CLI is not installed. Please install it first."
+        exit 1
+    fi
+
+    if ! az account show &> /dev/null; then
+        print_error "Not logged in to Azure. Please run 'az login' first."
+        exit 1
+    fi
+
+    if ! command -v kubectl &> /dev/null; then
+        print_error "kubectl is not installed. Please install it first."
+        exit 1
+    fi
+
+    print_message "All prerequisites met."
+}
+
+register_providers() {
+    print_message "Registering required resource providers..."
+
+    az provider register --namespace Microsoft.ContainerService --wait
+    az provider register --namespace Microsoft.Network --wait
+    az provider register --namespace Microsoft.NetworkFunction --wait
+    az provider register --namespace Microsoft.ServiceNetworking --wait
+
+    print_message "Registering preview features..."
+    az feature register --namespace "Microsoft.ContainerService" --name "ManagedGatewayAPIPreview" 2>/dev/null || true
+    az feature register --namespace "Microsoft.ContainerService" --name "ApplicationLoadBalancerPreview" 2>/dev/null || true
+
+    print_info "Waiting for feature registration (this may take a few minutes)..."
+    az feature show --namespace "Microsoft.ContainerService" --name "ManagedGatewayAPIPreview" --query "properties.state" -o tsv 2>/dev/null || true
+    az feature show --namespace "Microsoft.ContainerService" --name "ApplicationLoadBalancerPreview" --query "properties.state" -o tsv 2>/dev/null || true
+
+    az extension add --name alb --upgrade 2>/dev/null || true
+    az extension add --name aks-preview --upgrade 2>/dev/null || true
+
+    print_message "Provider registration complete."
+}
+
+deploy_infrastructure() {
+    print_message "Creating resource group: ${RESOURCE_GROUP_NAME}..."
+    az group create --name "${RESOURCE_GROUP_NAME}" --location "${LOCATION}" --output none
+
+    print_message "Deploying Bicep infrastructure (strategy: ${DEPLOYMENT_STRATEGY})..."
+    az deployment group create \
+        --name "${DEPLOYMENT_NAME}" \
+        --resource-group "${RESOURCE_GROUP_NAME}" \
+        --template-file main.bicep \
+        --parameters main.bicepparam \
+        --parameters deploymentStrategy="${DEPLOYMENT_STRATEGY}" \
+        --output none
+
+    print_message "Infrastructure deployment complete."
+}
+
+enable_alb_addon() {
+    print_message "Enabling Gateway API and Application Load Balancer add-on on AKS..."
+
+    az aks update \
+        --name "${AKS_NAME}" \
+        --resource-group "${RESOURCE_GROUP_NAME}" \
+        --enable-oidc-issuer \
+        --enable-workload-identity \
+        --enable-gateway-api \
+        --enable-application-load-balancer \
+        --no-wait \
+        --output none
+
+    print_info "Waiting for AKS update to complete..."
+    az aks wait --name "${AKS_NAME}" --resource-group "${RESOURCE_GROUP_NAME}" --updated
+
+    print_message "ALB Controller add-on enabled."
+}
+
+get_credentials() {
+    print_message "Getting AKS credentials..."
+    az aks get-credentials \
+        --resource-group "${RESOURCE_GROUP_NAME}" \
+        --name "${AKS_NAME}" \
+        --overwrite-existing
+}
+
+verify_alb_controller() {
+    print_message "Verifying ALB Controller installation..."
+
+    print_info "Waiting for ALB Controller pods to be ready..."
+    sleep 15
+
+    echo ""
+    print_info "ALB Controller pods:"
+    kubectl get pods -n kube-system | grep alb-controller || true
+
+    echo ""
+    print_info "Gateway classes:"
+    kubectl get gatewayclass || true
+
+    echo ""
+    print_message "ALB Controller verification complete."
+}
+
+setup_permissions_managed() {
+    print_message "Setting up permissions for ALB managed deployment..."
+
+    MC_RESOURCE_GROUP=$(az aks show --name "${AKS_NAME}" --resource-group "${RESOURCE_GROUP_NAME}" --query "nodeResourceGroup" -o tsv)
+
+    ALB_SUBNET_ID=$(az network vnet subnet show \
+        --name "${ALB_SUBNET_NAME}" \
+        --resource-group "${RESOURCE_GROUP_NAME}" \
+        --vnet-name "${VNET_NAME}" \
+        --query 'id' -o tsv)
+
+    # Get the managed identity created by the add-on
+    IDENTITY_NAME="applicationloadbalancer-${AKS_NAME}"
+    PRINCIPAL_ID=$(az identity show -g "${MC_RESOURCE_GROUP}" -n "${IDENTITY_NAME}" --query principalId -o tsv 2>/dev/null)
+
+    if [ -z "$PRINCIPAL_ID" ]; then
+        print_warning "ALB managed identity not found yet. Waiting 60 seconds..."
+        sleep 60
+        PRINCIPAL_ID=$(az identity show -g "${MC_RESOURCE_GROUP}" -n "${IDENTITY_NAME}" --query principalId -o tsv)
+    fi
+
+    MC_RG_ID=$(az group show --name "${MC_RESOURCE_GROUP}" --query id -o tsv)
+
+    print_info "Assigning AppGW for Containers Configuration Manager role to MC resource group..."
+    az role assignment create \
+        --assignee-object-id "${PRINCIPAL_ID}" \
+        --assignee-principal-type ServicePrincipal \
+        --scope "${MC_RG_ID}" \
+        --role "fbc52c3f-28ad-4303-a892-8a056630b8f1" \
+        --output none 2>/dev/null || true
+
+    print_info "Assigning Network Contributor role on ALB subnet..."
+    az role assignment create \
+        --assignee-object-id "${PRINCIPAL_ID}" \
+        --assignee-principal-type ServicePrincipal \
+        --scope "${ALB_SUBNET_ID}" \
+        --role "4d97b98b-1d4f-4787-a291-c67834d212e7" \
+        --output none 2>/dev/null || true
+
+    print_message "Permissions configured for ALB managed deployment."
+}
+
+setup_permissions_byo() {
+    print_message "Setting up permissions for BYO deployment..."
+
+    ALB_SUBNET_ID=$(az network vnet subnet show \
+        --name "${ALB_SUBNET_NAME}" \
+        --resource-group "${RESOURCE_GROUP_NAME}" \
+        --vnet-name "${VNET_NAME}" \
+        --query 'id' -o tsv)
+
+    MC_RESOURCE_GROUP=$(az aks show --name "${AKS_NAME}" --resource-group "${RESOURCE_GROUP_NAME}" --query "nodeResourceGroup" -o tsv)
+
+    # Get the managed identity created by the add-on
+    IDENTITY_NAME="applicationloadbalancer-${AKS_NAME}"
+    PRINCIPAL_ID=$(az identity show -g "${MC_RESOURCE_GROUP}" -n "${IDENTITY_NAME}" --query principalId -o tsv 2>/dev/null)
+
+    if [ -z "$PRINCIPAL_ID" ]; then
+        print_warning "ALB managed identity not found yet. Waiting 60 seconds..."
+        sleep 60
+        PRINCIPAL_ID=$(az identity show -g "${MC_RESOURCE_GROUP}" -n "${IDENTITY_NAME}" --query principalId -o tsv)
+    fi
+
+    RG_ID=$(az group show --name "${RESOURCE_GROUP_NAME}" --query id -o tsv)
+
+    print_info "Assigning AppGW for Containers Configuration Manager role to resource group..."
+    az role assignment create \
+        --assignee-object-id "${PRINCIPAL_ID}" \
+        --assignee-principal-type ServicePrincipal \
+        --scope "${RG_ID}" \
+        --role "fbc52c3f-28ad-4303-a892-8a056630b8f1" \
+        --output none 2>/dev/null || true
+
+    print_info "Assigning Network Contributor role on ALB subnet..."
+    az role assignment create \
+        --assignee-object-id "${PRINCIPAL_ID}" \
+        --assignee-principal-type ServicePrincipal \
+        --scope "${ALB_SUBNET_ID}" \
+        --role "4d97b98b-1d4f-4787-a291-c67834d212e7" \
+        --output none 2>/dev/null || true
+
+    print_message "Permissions configured for BYO deployment."
+}
+
+deploy_alb_managed() {
+    print_message "Deploying ApplicationLoadBalancer custom resource (ALB managed strategy)..."
+
+    ALB_SUBNET_ID=$(az network vnet subnet show \
+        --name "${ALB_SUBNET_NAME}" \
+        --resource-group "${RESOURCE_GROUP_NAME}" \
+        --vnet-name "${VNET_NAME}" \
+        --query 'id' -o tsv)
+
+    kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: alb-test-infra
+EOF
+
+    kubectl apply -f - <<EOF
+apiVersion: alb.networking.azure.io/v1
+kind: ApplicationLoadBalancer
+metadata:
+  name: alb-test
+  namespace: alb-test-infra
+spec:
+  associations:
+  - ${ALB_SUBNET_ID}
+EOF
+
+    print_info "Waiting for ApplicationLoadBalancer to be provisioned (this takes 5-6 minutes)..."
+    sleep 30
+    kubectl get applicationloadbalancer alb-test -n alb-test-infra -o yaml
+
+    print_message "ApplicationLoadBalancer resource deployed."
+}
+
+deploy_sample_apps() {
+    print_message "Deploying sample backend applications..."
+    kubectl apply -f kubernetes-manifests/01-sample-apps.yaml
+    print_info "Waiting for pods to be ready..."
+    kubectl wait --for=condition=ready pod -l app=backend-v1 -n test-infra --timeout=120s 2>/dev/null || true
+    kubectl wait --for=condition=ready pod -l app=backend-v2 -n test-infra --timeout=120s 2>/dev/null || true
+    print_message "Sample applications deployed."
+}
+
+deploy_gateway_managed() {
+    print_message "Deploying Gateway and HTTPRoutes (ALB managed strategy)..."
+    kubectl apply -f kubernetes-manifests/gateway-managed/
+    print_message "Gateway API resources deployed (ALB managed)."
+}
+
+deploy_gateway_byo() {
+    print_message "Deploying Gateway and HTTPRoutes (BYO strategy)..."
+
+    AGFC_ID=$(az network alb show --resource-group "${RESOURCE_GROUP_NAME}" --name "${AGFC_NAME}" --query id -o tsv)
+    FRONTEND_NAME="frontend"
+
+    # Apply the gateway template with BYO annotations
+    export AGFC_ID FRONTEND_NAME
+    envsubst < kubernetes-manifests/gateway-byo/02-gateway.yaml | kubectl apply -f -
+    kubectl apply -f kubernetes-manifests/gateway-byo/03-httproute.yaml
+
+    print_message "Gateway API resources deployed (BYO)."
+}
+
+wait_for_gateway() {
+    print_message "Waiting for Gateway to get an address (this may take a few minutes)..."
+    for i in $(seq 1 30); do
+        FQDN=$(kubectl get gateway gateway-01 -n test-infra -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || echo "")
+        if [ -n "$FQDN" ]; then
+            print_message "Gateway address assigned: ${FQDN}"
+            return
+        fi
+        sleep 10
+    done
+    print_warning "Gateway address not yet available. Check status with: kubectl get gateway gateway-01 -n test-infra -o yaml"
+}
+
+print_summary() {
+    echo ""
+    echo "=========================================="
+    echo "   Deployment Summary"
+    echo "=========================================="
+    echo ""
+    print_info "Resource Group:       ${RESOURCE_GROUP_NAME}"
+    print_info "AKS Cluster:          ${AKS_NAME}"
+    print_info "Deployment Strategy:  ${DEPLOYMENT_STRATEGY}"
+    echo ""
+
+    FQDN=$(kubectl get gateway gateway-01 -n test-infra -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || echo "pending")
+    print_info "Gateway FQDN: ${FQDN}"
+    echo ""
+
+    if [ "$FQDN" != "pending" ] && [ -n "$FQDN" ]; then
+        print_message "Test the application:"
+        echo ""
+        echo "  # Default route -> backend-v1"
+        echo "  curl http://${FQDN}/"
+        echo ""
+        echo "  # Path-based routing: /bar -> backend-v2"
+        echo "  curl http://${FQDN}/bar"
+        echo ""
+        echo "  # Header + query + path routing -> backend-v2"
+        echo "  curl http://${FQDN}/some/thing?great=example -H \"magic: foo\""
+        echo ""
+    else
+        print_warning "Gateway address not yet assigned. Run this to check:"
+        echo "  kubectl get gateway gateway-01 -n test-infra -o yaml"
+    fi
+    echo ""
+}
+
+# ===========================
+# Main Execution
+# ===========================
+echo ""
+echo "========================================================="
+echo "   AKS + Application Gateway for Containers Deployment"
+echo "   Strategy: ${DEPLOYMENT_STRATEGY}"
+echo "========================================================="
+echo ""
+
+check_prerequisites
+register_providers
+deploy_infrastructure
+enable_alb_addon
+get_credentials
+verify_alb_controller
+
+if [ "$DEPLOYMENT_STRATEGY" == "managed" ]; then
+    setup_permissions_managed
+    deploy_alb_managed
+    deploy_sample_apps
+    deploy_gateway_managed
+elif [ "$DEPLOYMENT_STRATEGY" == "byo" ]; then
+    setup_permissions_byo
+    deploy_sample_apps
+    deploy_gateway_byo
+fi
+
+wait_for_gateway
+print_summary
+
+print_message "Deployment complete!"

--- a/AKS-AppGW-Containers/kubernetes-manifests/01-sample-apps.yaml
+++ b/AKS-AppGW-Containers/kubernetes-manifests/01-sample-apps.yaml
@@ -1,0 +1,103 @@
+# Sample backend applications for Application Gateway for Containers demo
+# Creates two backend services to demonstrate Gateway API routing
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-infra
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend-v1
+  namespace: test-infra
+  labels:
+    app: backend-v1
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: backend-v1
+  template:
+    metadata:
+      labels:
+        app: backend-v1
+    spec:
+      containers:
+        - name: backend-v1
+          image: mcr.microsoft.com/dotnet/samples:aspnetapp
+          ports:
+            - containerPort: 8080
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-v1
+  namespace: test-infra
+spec:
+  selector:
+    app: backend-v1
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend-v2
+  namespace: test-infra
+  labels:
+    app: backend-v2
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: backend-v2
+  template:
+    metadata:
+      labels:
+        app: backend-v2
+    spec:
+      containers:
+        - name: backend-v2
+          image: mcr.microsoft.com/dotnet/samples:aspnetapp
+          ports:
+            - containerPort: 8080
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-v2
+  namespace: test-infra
+spec:
+  selector:
+    app: backend-v2
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080

--- a/AKS-AppGW-Containers/kubernetes-manifests/01-sample-apps.yaml
+++ b/AKS-AppGW-Containers/kubernetes-manifests/01-sample-apps.yaml
@@ -25,21 +25,19 @@ spec:
     spec:
       containers:
         - name: backend-v1
-          image: mcr.microsoft.com/dotnet/samples:aspnetapp
+          image: hashicorp/http-echo:0.2.3
+          args:
+            - "-text=backend-v1"
+            - "-listen=:8080"
           ports:
             - containerPort: 8080
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
           resources:
             requests:
-              cpu: 50m
-              memory: 64Mi
+              cpu: 10m
+              memory: 16Mi
             limits:
-              cpu: 250m
-              memory: 256Mi
+              cpu: 100m
+              memory: 64Mi
 ---
 apiVersion: v1
 kind: Service
@@ -73,21 +71,19 @@ spec:
     spec:
       containers:
         - name: backend-v2
-          image: mcr.microsoft.com/dotnet/samples:aspnetapp
+          image: hashicorp/http-echo:0.2.3
+          args:
+            - "-text=backend-v2"
+            - "-listen=:8080"
           ports:
             - containerPort: 8080
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
           resources:
             requests:
-              cpu: 50m
-              memory: 64Mi
+              cpu: 10m
+              memory: 16Mi
             limits:
-              cpu: 250m
-              memory: 256Mi
+              cpu: 100m
+              memory: 64Mi
 ---
 apiVersion: v1
 kind: Service

--- a/AKS-AppGW-Containers/kubernetes-manifests/02-backend-mtls-app.yaml
+++ b/AKS-AppGW-Containers/kubernetes-manifests/02-backend-mtls-app.yaml
@@ -1,0 +1,92 @@
+# Backend mTLS application — nginx configured for mutual TLS
+# Requires TLS secrets created by generate-tls-certs.sh (backend-mtls mode)
+#
+# This deploys an nginx pod that:
+#   - Listens on port 443 with TLS (server cert: backend.com)
+#   - Requires client certificate verification (using the CA cert)
+# The AGFC gateway presents its client cert (gateway-client-cert) to this backend.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mtls-app-nginx-cm
+  namespace: test-infra
+data:
+  default.conf: |
+    server {
+        listen 443 ssl;
+        server_name backend.com;
+
+        ssl_certificate     /etc/ssl/certs/backend/tls.crt;
+        ssl_certificate_key /etc/ssl/certs/backend/tls.key;
+
+        ssl_client_certificate /etc/ssl/certs/ca/ca.crt;
+        ssl_verify_client on;
+
+        location / {
+            return 200 "backend-mtls: client cert verified\n";
+            add_header Content-Type text/plain;
+        }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mtls-app
+  namespace: test-infra
+  labels:
+    app: mtls-app
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: mtls-app
+  template:
+    metadata:
+      labels:
+        app: mtls-app
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.27
+          ports:
+            - containerPort: 443
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d
+            - name: backend-cert
+              mountPath: /etc/ssl/certs/backend
+              readOnly: true
+            - name: ca-cert
+              mountPath: /etc/ssl/certs/ca
+              readOnly: true
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: mtls-app-nginx-cm
+        - name: backend-cert
+          secret:
+            secretName: backend.com
+        - name: ca-cert
+          secret:
+            secretName: ca.bundle
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mtls-app
+  namespace: test-infra
+spec:
+  selector:
+    app: mtls-app
+  ports:
+    - protocol: TCP
+      port: 443
+      targetPort: 443

--- a/AKS-AppGW-Containers/kubernetes-manifests/gateway-byo/02-gateway.yaml
+++ b/AKS-AppGW-Containers/kubernetes-manifests/gateway-byo/02-gateway.yaml
@@ -1,0 +1,27 @@
+# Gateway resource — BYO (Bring Your Own) strategy
+# AGFC resource, frontend, and association are pre-created in Azure via Bicep.
+# The Gateway references the existing AGFC by its resource ID.
+#
+# This template uses environment variable placeholders processed by envsubst:
+#   $AGFC_ID        — full Azure resource ID of the traffic controller
+#   $FRONTEND_NAME  — name of the pre-created frontend
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-01
+  namespace: test-infra
+  annotations:
+    alb.networking.azure.io/alb-id: $AGFC_ID
+spec:
+  gatewayClassName: azure-alb-external
+  listeners:
+    - name: http-listener
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+  addresses:
+    - type: alb.networking.azure.io/alb-frontend
+      value: $FRONTEND_NAME

--- a/AKS-AppGW-Containers/kubernetes-manifests/gateway-byo/03-httproute.yaml
+++ b/AKS-AppGW-Containers/kubernetes-manifests/gateway-byo/03-httproute.yaml
@@ -1,0 +1,40 @@
+# HTTPRoute — path-based and header-based routing demo (BYO)
+# Same routing rules as the managed strategy
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-route
+  namespace: test-infra
+spec:
+  parentRefs:
+    - name: gateway-01
+  rules:
+    # Path-based routing: /bar -> backend-v2
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /bar
+      backendRefs:
+        - name: backend-v2
+          port: 8080
+    # Header + query param + path routing -> backend-v2
+    - matches:
+        - headers:
+            - type: Exact
+              name: magic
+              value: foo
+          queryParams:
+            - type: Exact
+              name: great
+              value: example
+          path:
+            type: PathPrefix
+            value: /some/thing
+      backendRefs:
+        - name: backend-v2
+          port: 8080
+    # Default route -> backend-v1
+    - backendRefs:
+        - name: backend-v1
+          port: 8080

--- a/AKS-AppGW-Containers/kubernetes-manifests/gateway-byo/04-traffic-splitting.yaml
+++ b/AKS-AppGW-Containers/kubernetes-manifests/gateway-byo/04-traffic-splitting.yaml
@@ -1,0 +1,25 @@
+# Traffic Splitting / Weighted Round Robin — BYO
+# Splits traffic between backend-v1 (80%) and backend-v2 (20%)
+# Uses the existing gateway-01 and sample apps from 01-sample-apps.yaml
+#
+# Useful for canary deployments — gradually shift weight to the new version.
+# Adjust the weight values to control the traffic ratio.
+#
+# Ref: https://learn.microsoft.com/azure/application-gateway/for-containers/how-to-traffic-splitting-gateway-api
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: traffic-split-route
+  namespace: test-infra
+spec:
+  parentRefs:
+    - name: gateway-01
+  rules:
+    - backendRefs:
+        - name: backend-v1
+          port: 8080
+          weight: 80
+        - name: backend-v2
+          port: 8080
+          weight: 20

--- a/AKS-AppGW-Containers/kubernetes-manifests/gateway-byo/05-ssl-offloading.yaml
+++ b/AKS-AppGW-Containers/kubernetes-manifests/gateway-byo/05-ssl-offloading.yaml
@@ -1,0 +1,48 @@
+# SSL/TLS Offloading — BYO
+# Gateway terminates TLS (HTTPS on port 443) and forwards plain HTTP to backends.
+# Requires the listener-tls-secret — run generate-tls-certs.sh first.
+#
+# This template uses environment variable placeholders processed by envsubst:
+#   $AGFC_ID        — full Azure resource ID of the traffic controller
+#   $FRONTEND_NAME  — name of the pre-created frontend
+#
+# Ref: https://learn.microsoft.com/azure/application-gateway/for-containers/how-to-ssl-offloading-gateway-api
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-02-ssl
+  namespace: test-infra
+  annotations:
+    alb.networking.azure.io/alb-id: $AGFC_ID
+spec:
+  gatewayClassName: azure-alb-external
+  listeners:
+    - name: https-listener
+      port: 443
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: Same
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            group: ""
+            name: listener-tls-secret
+  addresses:
+    - type: alb.networking.azure.io/alb-frontend
+      value: $FRONTEND_NAME
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ssl-offloading-route
+  namespace: test-infra
+spec:
+  parentRefs:
+    - name: gateway-02-ssl
+  rules:
+    - backendRefs:
+        - name: backend-v1
+          port: 8080

--- a/AKS-AppGW-Containers/kubernetes-manifests/gateway-byo/06-backend-mtls.yaml
+++ b/AKS-AppGW-Containers/kubernetes-manifests/gateway-byo/06-backend-mtls.yaml
@@ -1,0 +1,81 @@
+# Backend mTLS — BYO
+# End-to-end encryption with mutual TLS between AGFC and the backend.
+#
+# Prerequisites:
+#   1. Run generate-tls-certs.sh backend-mtls (creates all required secrets)
+#   2. Apply 02-backend-mtls-app.yaml (deploys the mTLS nginx backend)
+#
+# This template uses environment variable placeholders processed by envsubst:
+#   $AGFC_ID        — full Azure resource ID of the traffic controller
+#   $FRONTEND_NAME  — name of the pre-created frontend
+#
+# Flow:
+#   Client --[HTTPS]--> AGFC (terminates TLS with frontend.com cert)
+#          --[mTLS]---> Backend (AGFC presents gateway-client-cert, backend verifies via CA)
+#
+# Ref: https://learn.microsoft.com/azure/application-gateway/for-containers/how-to-backend-mtls-gateway-api
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-03-mtls
+  namespace: test-infra
+  annotations:
+    alb.networking.azure.io/alb-id: $AGFC_ID
+spec:
+  gatewayClassName: azure-alb-external
+  listeners:
+    - name: https-listener
+      port: 443
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: Same
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            group: ""
+            name: frontend.com
+  addresses:
+    - type: alb.networking.azure.io/alb-frontend
+      value: $FRONTEND_NAME
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mtls-route
+  namespace: test-infra
+spec:
+  parentRefs:
+    - name: gateway-03-mtls
+  rules:
+    - backendRefs:
+        - name: mtls-app
+          port: 443
+---
+apiVersion: alb.networking.azure.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: mtls-app-tls-policy
+  namespace: test-infra
+spec:
+  targetRef:
+    group: ""
+    kind: Service
+    name: mtls-app
+    namespace: test-infra
+  default:
+    sni: backend.com
+    ports:
+      - port: 443
+    clientCertificateRef:
+      name: gateway-client-cert
+      group: ""
+      kind: Secret
+    verify:
+      caCertificateRef:
+        name: ca.bundle
+        group: ""
+        kind: Secret
+      subjectAltName: backend.com

--- a/AKS-AppGW-Containers/kubernetes-manifests/gateway-managed/02-gateway.yaml
+++ b/AKS-AppGW-Containers/kubernetes-manifests/gateway-managed/02-gateway.yaml
@@ -1,0 +1,21 @@
+# Gateway resource — ALB Controller managed strategy
+# The ALB Controller creates and manages the AGFC resource lifecycle
+# via the ApplicationLoadBalancer CRD deployed separately in deploy.sh
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-01
+  namespace: test-infra
+  annotations:
+    alb.networking.azure.io/alb-namespace: alb-test-infra
+    alb.networking.azure.io/alb-name: alb-test
+spec:
+  gatewayClassName: azure-alb-external
+  listeners:
+    - name: http-listener
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same

--- a/AKS-AppGW-Containers/kubernetes-manifests/gateway-managed/03-httproute.yaml
+++ b/AKS-AppGW-Containers/kubernetes-manifests/gateway-managed/03-httproute.yaml
@@ -1,0 +1,40 @@
+# HTTPRoute — path-based and header-based routing demo (ALB managed)
+# Matches the MS Learn path/header routing quick-start examples
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-route
+  namespace: test-infra
+spec:
+  parentRefs:
+    - name: gateway-01
+  rules:
+    # Path-based routing: /bar -> backend-v2
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /bar
+      backendRefs:
+        - name: backend-v2
+          port: 8080
+    # Header + query param + path routing -> backend-v2
+    - matches:
+        - headers:
+            - type: Exact
+              name: magic
+              value: foo
+          queryParams:
+            - type: Exact
+              name: great
+              value: example
+          path:
+            type: PathPrefix
+            value: /some/thing
+      backendRefs:
+        - name: backend-v2
+          port: 8080
+    # Default route -> backend-v1
+    - backendRefs:
+        - name: backend-v1
+          port: 8080

--- a/AKS-AppGW-Containers/kubernetes-manifests/gateway-managed/04-traffic-splitting.yaml
+++ b/AKS-AppGW-Containers/kubernetes-manifests/gateway-managed/04-traffic-splitting.yaml
@@ -1,0 +1,25 @@
+# Traffic Splitting / Weighted Round Robin — ALB managed
+# Splits traffic between backend-v1 (80%) and backend-v2 (20%)
+# Uses the existing gateway-01 and sample apps from 01-sample-apps.yaml
+#
+# Useful for canary deployments — gradually shift weight to the new version.
+# Adjust the weight values to control the traffic ratio.
+#
+# Ref: https://learn.microsoft.com/azure/application-gateway/for-containers/how-to-traffic-splitting-gateway-api
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: traffic-split-route
+  namespace: test-infra
+spec:
+  parentRefs:
+    - name: gateway-01
+  rules:
+    - backendRefs:
+        - name: backend-v1
+          port: 8080
+          weight: 80
+        - name: backend-v2
+          port: 8080
+          weight: 20

--- a/AKS-AppGW-Containers/kubernetes-manifests/gateway-managed/05-ssl-offloading.yaml
+++ b/AKS-AppGW-Containers/kubernetes-manifests/gateway-managed/05-ssl-offloading.yaml
@@ -1,0 +1,42 @@
+# SSL/TLS Offloading — ALB managed
+# Gateway terminates TLS (HTTPS on port 443) and forwards plain HTTP to backends.
+# Requires the listener-tls-secret — run generate-tls-certs.sh first.
+#
+# Ref: https://learn.microsoft.com/azure/application-gateway/for-containers/how-to-ssl-offloading-gateway-api
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-02-ssl
+  namespace: test-infra
+  annotations:
+    alb.networking.azure.io/alb-namespace: alb-test-infra
+    alb.networking.azure.io/alb-name: alb-test
+spec:
+  gatewayClassName: azure-alb-external
+  listeners:
+    - name: https-listener
+      port: 443
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: Same
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            group: ""
+            name: listener-tls-secret
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ssl-offloading-route
+  namespace: test-infra
+spec:
+  parentRefs:
+    - name: gateway-02-ssl
+  rules:
+    - backendRefs:
+        - name: backend-v1
+          port: 8080

--- a/AKS-AppGW-Containers/kubernetes-manifests/gateway-managed/06-backend-mtls.yaml
+++ b/AKS-AppGW-Containers/kubernetes-manifests/gateway-managed/06-backend-mtls.yaml
@@ -1,0 +1,75 @@
+# Backend mTLS — ALB managed
+# End-to-end encryption with mutual TLS between AGFC and the backend.
+#
+# Prerequisites:
+#   1. Run generate-tls-certs.sh backend-mtls (creates all required secrets)
+#   2. Apply 02-backend-mtls-app.yaml (deploys the mTLS nginx backend)
+#
+# Flow:
+#   Client --[HTTPS]--> AGFC (terminates TLS with frontend.com cert)
+#          --[mTLS]---> Backend (AGFC presents gateway-client-cert, backend verifies via CA)
+#
+# Ref: https://learn.microsoft.com/azure/application-gateway/for-containers/how-to-backend-mtls-gateway-api
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-03-mtls
+  namespace: test-infra
+  annotations:
+    alb.networking.azure.io/alb-namespace: alb-test-infra
+    alb.networking.azure.io/alb-name: alb-test
+spec:
+  gatewayClassName: azure-alb-external
+  listeners:
+    - name: https-listener
+      port: 443
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: Same
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            group: ""
+            name: frontend.com
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mtls-route
+  namespace: test-infra
+spec:
+  parentRefs:
+    - name: gateway-03-mtls
+  rules:
+    - backendRefs:
+        - name: mtls-app
+          port: 443
+---
+apiVersion: alb.networking.azure.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: mtls-app-tls-policy
+  namespace: test-infra
+spec:
+  targetRef:
+    group: ""
+    kind: Service
+    name: mtls-app
+    namespace: test-infra
+  default:
+    sni: backend.com
+    ports:
+      - port: 443
+    clientCertificateRef:
+      name: gateway-client-cert
+      group: ""
+      kind: Secret
+    verify:
+      caCertificateRef:
+        name: ca.bundle
+        group: ""
+        kind: Secret
+      subjectAltName: backend.com

--- a/AKS-AppGW-Containers/kubernetes-manifests/generate-tls-certs.sh
+++ b/AKS-AppGW-Containers/kubernetes-manifests/generate-tls-certs.sh
@@ -8,7 +8,12 @@
 set -euo pipefail
 
 NAMESPACE="test-infra"
-CERT_DIR="$(mktemp -d)"
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    CERT_DIR="$(mktemp -d -t agfc-certs)"
+else
+    CERT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/agfc-certs.XXXXXX")"
+fi
+trap 'rm -rf "$CERT_DIR"' EXIT
 SCENARIO="${1:-all}"
 
 echo "=== Generating TLS certificates in $CERT_DIR ==="
@@ -111,5 +116,4 @@ esac
 
 echo ""
 echo "=== Done — cleaning up temp files ==="
-rm -rf "$CERT_DIR"
 echo "Certificates created successfully in namespace $NAMESPACE"

--- a/AKS-AppGW-Containers/kubernetes-manifests/generate-tls-certs.sh
+++ b/AKS-AppGW-Containers/kubernetes-manifests/generate-tls-certs.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Generate self-signed TLS certificates for AGFC demo scenarios
+# - SSL Offloading: creates listener-tls-secret
+# - Backend mTLS: creates frontend.com, backend.com, gateway-client-cert, ca.bundle
+#
+# Usage: ./generate-tls-certs.sh [ssl-offloading|backend-mtls|all]
+# Default: all
+set -euo pipefail
+
+NAMESPACE="test-infra"
+CERT_DIR="$(mktemp -d)"
+SCENARIO="${1:-all}"
+
+echo "=== Generating TLS certificates in $CERT_DIR ==="
+
+# ----- Helper -----
+generate_ca() {
+    echo "--- Creating Certificate Authority ---"
+    openssl ecparam -name prime256v1 -genkey -noout -out "$CERT_DIR/ca.key"
+    openssl req -new -x509 -sha256 -key "$CERT_DIR/ca.key" \
+        -subj "/O=AGFC Demo/CN=AGFC Demo CA" \
+        -days 365 -out "$CERT_DIR/ca.crt"
+}
+
+generate_cert() {
+    local name="$1" cn="$2"
+    echo "--- Generating certificate for $cn ---"
+    openssl ecparam -name prime256v1 -genkey -noout -out "$CERT_DIR/${name}.key"
+    openssl req -new -sha256 -key "$CERT_DIR/${name}.key" \
+        -subj "/O=AGFC Demo/CN=${cn}" \
+        -out "$CERT_DIR/${name}.csr"
+    openssl x509 -req -sha256 -in "$CERT_DIR/${name}.csr" \
+        -CA "$CERT_DIR/ca.crt" -CAkey "$CERT_DIR/ca.key" -CAcreateserial \
+        -days 365 -out "$CERT_DIR/${name}.crt" \
+        -extfile <(printf "subjectAltName=DNS:%s" "$cn")
+}
+
+# ----- SSL Offloading certs -----
+create_ssl_offloading_secret() {
+    echo ""
+    echo "=== SSL Offloading — listener-tls-secret ==="
+    openssl ecparam -name prime256v1 -genkey -noout -out "$CERT_DIR/listener.key"
+    openssl req -new -x509 -sha256 -key "$CERT_DIR/listener.key" \
+        -subj "/O=AGFC Demo/CN=agfc-demo.example.com" \
+        -days 365 -out "$CERT_DIR/listener.crt"
+
+    kubectl create secret tls listener-tls-secret \
+        --cert="$CERT_DIR/listener.crt" \
+        --key="$CERT_DIR/listener.key" \
+        -n "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+    echo "  ✓ listener-tls-secret created"
+}
+
+# ----- Backend mTLS certs -----
+create_backend_mtls_secrets() {
+    echo ""
+    echo "=== Backend mTLS — CA, server, client, and frontend certs ==="
+    generate_ca
+
+    # Frontend cert (for the Gateway HTTPS listener)
+    generate_cert "frontend" "frontend.com"
+
+    # Backend cert (server cert for the mTLS nginx backend)
+    generate_cert "backend" "backend.com"
+
+    # Gateway client cert (presented by AGFC to the backend)
+    generate_cert "gateway-client" "gateway.agfc.example.com"
+
+    # Create Kubernetes secrets
+    kubectl create secret tls frontend.com \
+        --cert="$CERT_DIR/frontend.crt" \
+        --key="$CERT_DIR/frontend.key" \
+        -n "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+    echo "  ✓ frontend.com secret created"
+
+    kubectl create secret tls backend.com \
+        --cert="$CERT_DIR/backend.crt" \
+        --key="$CERT_DIR/backend.key" \
+        -n "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+    echo "  ✓ backend.com secret created"
+
+    kubectl create secret tls gateway-client-cert \
+        --cert="$CERT_DIR/gateway-client.crt" \
+        --key="$CERT_DIR/gateway-client.key" \
+        -n "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+    echo "  ✓ gateway-client-cert secret created"
+
+    kubectl create secret generic ca.bundle \
+        --from-file=ca.crt="$CERT_DIR/ca.crt" \
+        -n "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+    echo "  ✓ ca.bundle secret created"
+}
+
+# ----- Main -----
+case "$SCENARIO" in
+    ssl-offloading)
+        create_ssl_offloading_secret
+        ;;
+    backend-mtls)
+        create_backend_mtls_secrets
+        ;;
+    all)
+        create_ssl_offloading_secret
+        create_backend_mtls_secrets
+        ;;
+    *)
+        echo "Usage: $0 [ssl-offloading|backend-mtls|all]"
+        exit 1
+        ;;
+esac
+
+echo ""
+echo "=== Done — cleaning up temp files ==="
+rm -rf "$CERT_DIR"
+echo "Certificates created successfully in namespace $NAMESPACE"

--- a/AKS-AppGW-Containers/main.bicep
+++ b/AKS-AppGW-Containers/main.bicep
@@ -1,0 +1,115 @@
+// Main Bicep template for AKS with Application Gateway for Containers
+// Supports two deployment strategies:
+//   - 'byo'     : Bring Your Own — AGFC resource, frontend, and association created in Azure via Bicep
+//   - 'managed' : Managed by ALB Controller — lifecycle managed via ApplicationLoadBalancer CRD in Kubernetes
+
+targetScope = 'resourceGroup'
+
+@description('The Azure region for all resources')
+param location string = resourceGroup().location
+
+@description('The name prefix for all resources')
+@minLength(3)
+@maxLength(10)
+param namePrefix string = 'agfc'
+
+@description('Environment name (dev, test, prod)')
+@allowed([
+  'dev'
+  'test'
+  'prod'
+])
+param environment string = 'dev'
+
+@description('AKS Kubernetes version')
+param kubernetesVersion string = '1.31.2'
+
+@description('System node pool count')
+@minValue(1)
+@maxValue(5)
+param systemNodeCount int = 2
+
+@description('System node pool VM size')
+param systemNodeVmSize string = 'Standard_D2s_v3'
+
+@description('Enable Azure Monitor Container Insights')
+param enableMonitoring bool = true
+
+@description('Deployment strategy: byo (Bring Your Own) or managed (ALB Controller managed)')
+@allowed([
+  'byo'
+  'managed'
+])
+param deploymentStrategy string = 'managed'
+
+@description('Tags to apply to all resources')
+param tags object = {
+  Environment: environment
+  Project: 'AKS-AppGW-Containers'
+  ManagedBy: 'Bicep'
+}
+
+// Variables
+var aksClusterName = '${namePrefix}-aks-${environment}'
+var logAnalyticsName = '${namePrefix}-logs-${environment}'
+var vnetName = '${namePrefix}-vnet-${environment}'
+var agfcName = '${namePrefix}-agfc-${environment}'
+
+// Log Analytics Workspace
+module logAnalytics 'modules/log-analytics.bicep' = {
+  name: 'log-analytics-deployment'
+  params: {
+    workspaceName: logAnalyticsName
+    location: location
+    tags: tags
+  }
+}
+
+// Virtual Network with ALB delegated subnet
+module vnet 'modules/vnet.bicep' = {
+  name: 'vnet-deployment'
+  params: {
+    vnetName: vnetName
+    location: location
+    tags: tags
+  }
+}
+
+// AKS Cluster with Azure CNI Overlay, OIDC, Workload Identity
+module aks 'modules/aks.bicep' = {
+  name: 'aks-deployment'
+  params: {
+    clusterName: aksClusterName
+    location: location
+    kubernetesVersion: kubernetesVersion
+    systemNodeCount: systemNodeCount
+    systemNodeVmSize: systemNodeVmSize
+    subnetId: vnet.outputs.aksSubnetId
+    logAnalyticsWorkspaceId: logAnalytics.outputs.workspaceId
+    enableMonitoring: enableMonitoring
+    tags: tags
+  }
+}
+
+// Application Gateway for Containers (BYO strategy only)
+// For 'managed' strategy, the AGFC resource is created via ApplicationLoadBalancer CRD in Kubernetes
+module agfc 'modules/agfc.bicep' = if (deploymentStrategy == 'byo') {
+  name: 'agfc-deployment'
+  params: {
+    agfcName: agfcName
+    location: location
+    albSubnetId: vnet.outputs.albSubnetId
+    tags: tags
+  }
+}
+
+// Outputs
+output aksClusterName string = aks.outputs.clusterName
+output aksClusterFqdn string = aks.outputs.clusterFqdn
+output nodeResourceGroup string = aks.outputs.nodeResourceGroup
+output albSubnetId string = vnet.outputs.albSubnetId
+output vnetName string = vnet.outputs.vnetName
+output deploymentStrategy string = deploymentStrategy
+output agfcName string = deploymentStrategy == 'byo' ? agfc.outputs.agfcName : 'managed-by-alb-controller'
+output agfcId string = deploymentStrategy == 'byo' ? agfc.outputs.agfcId : ''
+output frontendName string = deploymentStrategy == 'byo' ? agfc.outputs.frontendName : ''

--- a/AKS-AppGW-Containers/main.bicep
+++ b/AKS-AppGW-Containers/main.bicep
@@ -82,6 +82,7 @@ module aks 'modules/aks.bicep' = {
     clusterName: aksClusterName
     location: location
     kubernetesVersion: kubernetesVersion
+    nodeResourceGroupName: 'rg-${namePrefix}-${environment}-nodes'
     systemNodeCount: systemNodeCount
     systemNodeVmSize: systemNodeVmSize
     subnetId: vnet.outputs.aksSubnetId

--- a/AKS-AppGW-Containers/main.bicepparam
+++ b/AKS-AppGW-Containers/main.bicepparam
@@ -4,7 +4,7 @@ using './main.bicep'
 param namePrefix = 'agfc'
 param environment = 'dev'
 param location = 'northeurope'
-param kubernetesVersion = '1.31.2'
+param kubernetesVersion = '1.34.2'
 param systemNodeCount = 2
 param systemNodeVmSize = 'Standard_D2s_v3'
 param enableMonitoring = true

--- a/AKS-AppGW-Containers/main.bicepparam
+++ b/AKS-AppGW-Containers/main.bicepparam
@@ -1,0 +1,22 @@
+// Parameters file for AKS with Application Gateway for Containers Demo
+using './main.bicep'
+
+param namePrefix = 'agfc'
+param environment = 'dev'
+param location = 'northeurope'
+param kubernetesVersion = '1.31.2'
+param systemNodeCount = 2
+param systemNodeVmSize = 'Standard_D2s_v3'
+param enableMonitoring = true
+
+// Deployment strategy: 'byo' or 'managed'
+// - 'byo'     : AGFC resource created in Azure via Bicep, referenced by Gateway in K8s
+// - 'managed' : AGFC resource created automatically via ApplicationLoadBalancer CRD in K8s
+param deploymentStrategy = 'managed'
+
+param tags = {
+  Environment: 'dev'
+  Project: 'AKS-AppGW-Containers'
+  ManagedBy: 'Bicep'
+  Owner: 'DevOps'
+}

--- a/AKS-AppGW-Containers/modules/agfc.bicep
+++ b/AKS-AppGW-Containers/modules/agfc.bicep
@@ -1,0 +1,52 @@
+// Application Gateway for Containers Module (BYO Deployment Strategy)
+// Creates the AGFC resource, frontend, and association in Azure
+// Lifecycle is managed in Azure, independent from Kubernetes
+
+@description('Name of the Application Gateway for Containers resource')
+param agfcName string
+
+@description('Location for the AGFC resource')
+param location string
+
+@description('Name of the frontend resource')
+param frontendName string = 'frontend'
+
+@description('Name of the association resource')
+param associationName string = 'association'
+
+@description('Subnet ID for the ALB association (must be delegated to Microsoft.ServiceNetworking/trafficControllers)')
+param albSubnetId string
+
+@description('Tags for resources')
+param tags object
+
+resource agfc 'Microsoft.ServiceNetworking/trafficControllers@2025-01-01' = {
+  name: agfcName
+  location: location
+  tags: tags
+  properties: {}
+}
+
+resource frontend 'Microsoft.ServiceNetworking/trafficControllers/frontends@2025-01-01' = {
+  parent: agfc
+  name: frontendName
+  location: location
+  properties: {}
+}
+
+resource association 'Microsoft.ServiceNetworking/trafficControllers/associations@2025-01-01' = {
+  parent: agfc
+  name: associationName
+  location: location
+  properties: {
+    associationType: 'subnets'
+    subnet: {
+      id: albSubnetId
+    }
+  }
+}
+
+output agfcId string = agfc.id
+output agfcName string = agfc.name
+output frontendName string = frontend.name
+output frontendFqdn string = frontend.properties.fqdn

--- a/AKS-AppGW-Containers/modules/aks.bicep
+++ b/AKS-AppGW-Containers/modules/aks.bicep
@@ -25,6 +25,9 @@ param logAnalyticsWorkspaceId string
 @description('Enable monitoring')
 param enableMonitoring bool
 
+@description('Custom node resource group name')
+param nodeResourceGroupName string
+
 @description('Tags for the cluster')
 param tags object
 
@@ -38,6 +41,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
   properties: {
     kubernetesVersion: kubernetesVersion
     dnsPrefix: clusterName
+    nodeResourceGroup: nodeResourceGroupName
     enableRBAC: true
 
     agentPoolProfiles: [

--- a/AKS-AppGW-Containers/modules/aks.bicep
+++ b/AKS-AppGW-Containers/modules/aks.bicep
@@ -1,0 +1,97 @@
+// AKS Cluster Module - Application Gateway for Containers
+// Deploys AKS with Azure CNI Overlay, OIDC Issuer, and Workload Identity
+
+@description('The name of the AKS cluster')
+param clusterName string
+
+@description('The location of the AKS cluster')
+param location string
+
+@description('Kubernetes version')
+param kubernetesVersion string
+
+@description('Number of nodes in the system node pool')
+param systemNodeCount int
+
+@description('VM size for system nodes')
+param systemNodeVmSize string
+
+@description('Subnet ID for AKS nodes')
+param subnetId string
+
+@description('Log Analytics Workspace ID for monitoring')
+param logAnalyticsWorkspaceId string
+
+@description('Enable monitoring')
+param enableMonitoring bool
+
+@description('Tags for the cluster')
+param tags object
+
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
+  name: clusterName
+  location: location
+  tags: tags
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    kubernetesVersion: kubernetesVersion
+    dnsPrefix: clusterName
+    enableRBAC: true
+
+    agentPoolProfiles: [
+      {
+        name: 'system'
+        count: systemNodeCount
+        vmSize: systemNodeVmSize
+        mode: 'System'
+        type: 'VirtualMachineScaleSets'
+        osType: 'Linux'
+        osSKU: 'AzureLinux'
+        vnetSubnetID: subnetId
+        maxPods: 250
+        enableAutoScaling: true
+        minCount: 1
+        maxCount: 3
+      }
+    ]
+
+    networkProfile: {
+      networkPlugin: 'azure'
+      networkPluginMode: 'overlay'
+      networkPolicy: 'cilium'
+      networkDataplane: 'cilium'
+      podCidr: '10.244.0.0/16'
+      serviceCidr: '10.2.0.0/16'
+      dnsServiceIP: '10.2.0.10'
+      loadBalancerSku: 'standard'
+      outboundType: 'loadBalancer'
+    }
+
+    oidcIssuerProfile: {
+      enabled: true
+    }
+
+    securityProfile: {
+      workloadIdentity: {
+        enabled: true
+      }
+    }
+
+    addonProfiles: {
+      omsagent: {
+        enabled: enableMonitoring
+        config: enableMonitoring ? {
+          logAnalyticsWorkspaceResourceID: logAnalyticsWorkspaceId
+        } : null
+      }
+    }
+  }
+}
+
+output clusterName string = aksCluster.name
+output clusterFqdn string = aksCluster.properties.fqdn
+output nodeResourceGroup string = aksCluster.properties.nodeResourceGroup
+output oidcIssuerUrl string = aksCluster.properties.oidcIssuerProfile.issuerURL
+output kubeletIdentityObjectId string = aksCluster.properties.identityProfile.kubeletidentity.objectId

--- a/AKS-AppGW-Containers/modules/aks.bicep
+++ b/AKS-AppGW-Containers/modules/aks.bicep
@@ -57,7 +57,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
         maxPods: 250
         enableAutoScaling: true
         minCount: 1
-        maxCount: 3
+        maxCount: max(systemNodeCount, 3)
       }
     ]
 

--- a/AKS-AppGW-Containers/modules/log-analytics.bicep
+++ b/AKS-AppGW-Containers/modules/log-analytics.bicep
@@ -1,0 +1,25 @@
+// Log Analytics Workspace Module for AKS Monitoring
+
+@description('Name of the Log Analytics workspace')
+param workspaceName string
+
+@description('Location for the workspace')
+param location string
+
+@description('Tags for the workspace')
+param tags object
+
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: workspaceName
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+}
+
+output workspaceId string = logAnalytics.id
+output workspaceName string = logAnalytics.name

--- a/AKS-AppGW-Containers/modules/vnet.bicep
+++ b/AKS-AppGW-Containers/modules/vnet.bicep
@@ -29,35 +29,38 @@ resource vnet 'Microsoft.Network/virtualNetworks@2023-11-01' = {
         vnetAddressPrefix
       ]
     }
-    subnets: [
+  }
+}
+
+resource aksSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' = {
+  parent: vnet
+  name: 'aks-subnet'
+  properties: {
+    addressPrefix: aksSubnetPrefix
+    privateEndpointNetworkPolicies: 'Disabled'
+    privateLinkServiceNetworkPolicies: 'Enabled'
+  }
+}
+
+resource albSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' = {
+  parent: vnet
+  name: 'subnet-alb'
+  properties: {
+    addressPrefix: albSubnetPrefix
+    delegations: [
       {
-        name: 'aks-subnet'
+        name: 'Microsoft.ServiceNetworking.trafficControllers'
         properties: {
-          addressPrefix: aksSubnetPrefix
-          privateEndpointNetworkPolicies: 'Disabled'
-          privateLinkServiceNetworkPolicies: 'Enabled'
-        }
-      }
-      {
-        name: 'subnet-alb'
-        properties: {
-          addressPrefix: albSubnetPrefix
-          delegations: [
-            {
-              name: 'Microsoft.ServiceNetworking.trafficControllers'
-              properties: {
-                serviceName: 'Microsoft.ServiceNetworking/trafficControllers'
-              }
-            }
-          ]
+          serviceName: 'Microsoft.ServiceNetworking/trafficControllers'
         }
       }
     ]
   }
+  dependsOn: [aksSubnet]
 }
 
 output vnetId string = vnet.id
 output vnetName string = vnet.name
-output aksSubnetId string = vnet.properties.subnets[0].id
-output albSubnetId string = vnet.properties.subnets[1].id
-output albSubnetName string = vnet.properties.subnets[1].name
+output aksSubnetId string = aksSubnet.id
+output albSubnetId string = albSubnet.id
+output albSubnetName string = albSubnet.name

--- a/AKS-AppGW-Containers/modules/vnet.bicep
+++ b/AKS-AppGW-Containers/modules/vnet.bicep
@@ -1,0 +1,63 @@
+// Virtual Network Module for AKS with Application Gateway for Containers
+// Includes AKS subnet and a delegated subnet for ALB association
+
+@description('Name of the virtual network')
+param vnetName string
+
+@description('Location for the virtual network')
+param location string
+
+@description('Tags for the virtual network')
+param tags object
+
+@description('VNet address space')
+param vnetAddressPrefix string = '10.0.0.0/8'
+
+@description('AKS nodes subnet address prefix')
+param aksSubnetPrefix string = '10.224.0.0/16'
+
+@description('Application Gateway for Containers association subnet prefix (min /24 with 250+ IPs)')
+param albSubnetPrefix string = '10.225.0.0/24'
+
+resource vnet 'Microsoft.Network/virtualNetworks@2023-11-01' = {
+  name: vnetName
+  location: location
+  tags: tags
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        vnetAddressPrefix
+      ]
+    }
+    subnets: [
+      {
+        name: 'aks-subnet'
+        properties: {
+          addressPrefix: aksSubnetPrefix
+          privateEndpointNetworkPolicies: 'Disabled'
+          privateLinkServiceNetworkPolicies: 'Enabled'
+        }
+      }
+      {
+        name: 'subnet-alb'
+        properties: {
+          addressPrefix: albSubnetPrefix
+          delegations: [
+            {
+              name: 'Microsoft.ServiceNetworking.trafficControllers'
+              properties: {
+                serviceName: 'Microsoft.ServiceNetworking/trafficControllers'
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+
+output vnetId string = vnet.id
+output vnetName string = vnet.name
+output aksSubnetId string = vnet.properties.subnets[0].id
+output albSubnetId string = vnet.properties.subnets[1].id
+output albSubnetName string = vnet.properties.subnets[1].name

--- a/AKS-Desktop/main.bicep
+++ b/AKS-Desktop/main.bicep
@@ -120,6 +120,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-07-02-previ
     type: 'SystemAssigned'
   }
   properties: {
+    nodeResourceGroup: 'rg-${clusterName}-nodes'
     agentPoolProfiles: [
       {
         name: 'systempool'

--- a/AKS-Fleet-Manager-Demo/main.bicep
+++ b/AKS-Fleet-Manager-Demo/main.bicep
@@ -113,6 +113,7 @@ module aksDev1 'modules/aks-member.bicep' = {
     clusterName: devCluster1Name
     location: clusterLocation1
     kubernetesVersion: devKubernetesVersion
+    nodeResourceGroupName: 'rg-${devCluster1Name}-nodes'
     subnetId: vnet1.outputs.aksSubnetId
     logAnalyticsWorkspaceId: logAnalytics.outputs.workspaceId
     tags: union(tags, { Environment: 'dev', Cluster: 'dev-1', Region: clusterLocation1 })
@@ -127,6 +128,7 @@ module aksDev2 'modules/aks-member.bicep' = {
     clusterName: devCluster2Name
     location: clusterLocation2
     kubernetesVersion: devKubernetesVersion
+    nodeResourceGroupName: 'rg-${devCluster2Name}-nodes'
     subnetId: vnet2.outputs.aksSubnetId
     logAnalyticsWorkspaceId: logAnalytics.outputs.workspaceId
     tags: union(tags, { Environment: 'dev', Cluster: 'dev-2-standalone', Region: clusterLocation2, Standalone: 'true' })
@@ -145,6 +147,7 @@ module aksAcc1 'modules/aks-member.bicep' = {
     clusterName: accCluster1Name
     location: clusterLocation1
     kubernetesVersion: accKubernetesVersion
+    nodeResourceGroupName: 'rg-${accCluster1Name}-nodes'
     subnetId: vnet1.outputs.aksSubnetId
     logAnalyticsWorkspaceId: logAnalytics.outputs.workspaceId
     tags: union(tags, { Environment: 'acc', Cluster: 'acc-1', Region: clusterLocation1 })
@@ -159,6 +162,7 @@ module aksAcc2 'modules/aks-member.bicep' = {
     clusterName: accCluster2Name
     location: clusterLocation2
     kubernetesVersion: accKubernetesVersion
+    nodeResourceGroupName: 'rg-${accCluster2Name}-nodes'
     subnetId: vnet2.outputs.aksSubnetId
     logAnalyticsWorkspaceId: logAnalytics.outputs.workspaceId
     tags: union(tags, { Environment: 'acc', Cluster: 'acc-2', Region: clusterLocation2 })
@@ -177,6 +181,7 @@ module aksProd1 'modules/aks-member.bicep' = {
     clusterName: prodCluster1Name
     location: clusterLocation1
     kubernetesVersion: prodKubernetesVersion
+    nodeResourceGroupName: 'rg-${prodCluster1Name}-nodes'
     subnetId: vnet1.outputs.aksSubnetId
     logAnalyticsWorkspaceId: logAnalytics.outputs.workspaceId
     tags: union(tags, { Environment: 'prod', Cluster: 'prod-1', Region: clusterLocation1 })
@@ -191,6 +196,7 @@ module aksProd2 'modules/aks-member.bicep' = {
     clusterName: prodCluster2Name
     location: clusterLocation2
     kubernetesVersion: prodKubernetesVersion
+    nodeResourceGroupName: 'rg-${prodCluster2Name}-nodes'
     subnetId: vnet2.outputs.aksSubnetId
     logAnalyticsWorkspaceId: logAnalytics.outputs.workspaceId
     tags: union(tags, { Environment: 'prod', Cluster: 'prod-2', Region: clusterLocation2 })

--- a/AKS-Fleet-Manager-Demo/modules/aks-member.bicep
+++ b/AKS-Fleet-Manager-Demo/modules/aks-member.bicep
@@ -15,6 +15,9 @@ param subnetId string
 @description('Log Analytics Workspace ID')
 param logAnalyticsWorkspaceId string
 
+@description('Custom node resource group name')
+param nodeResourceGroupName string
+
 @description('Resource tags')
 param tags object = {}
 
@@ -37,6 +40,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-02-01' = {
   properties: {
     dnsPrefix: clusterName
     kubernetesVersion: kubernetesVersion
+    nodeResourceGroup: nodeResourceGroupName
     enableRBAC: true
     networkProfile: {
       networkPlugin: 'azure'

--- a/AKS-Monitoring/aks-monitoring.bicep
+++ b/AKS-Monitoring/aks-monitoring.bicep
@@ -28,6 +28,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-07-02-previ
       clientId: 'msi'
     }
     kubernetesVersion: '1.30.7'
+    nodeResourceGroup: 'rg-${name}-nodes'
     autoUpgradeProfile: {
       upgradeChannel: 'stable'
     }

--- a/AKS-Nginx-Add-on/Create-AKS-Nginx-Add-On/commands.sh
+++ b/AKS-Nginx-Add-on/Create-AKS-Nginx-Add-On/commands.sh
@@ -14,7 +14,7 @@ az group create --name $ResourceGroupName --location $Location
 
 # Create an AKS cluster
 
-az aks create --resource-group $ResourceGroupName --name $ClusterName --location $Location --enable-app-routing --generate-ssh-keys
+az aks create --resource-group $ResourceGroupName --name $ClusterName --location $Location --node-resource-group "rg-${ClusterName}-nodes" --enable-app-routing --generate-ssh-keys
 
 # Get the credentials for the AKS cluster
 

--- a/AKS-Node-Autoprovision/commands.azcli
+++ b/AKS-Node-Autoprovision/commands.azcli
@@ -35,7 +35,7 @@ az group create --name $RESOURCE_GROUP_NAME --location $LOCATION
 
 # Create an AKS cluster with Node autoprovisioning
 
-az aks create --name $CLUSTER_NAME --resource-group $RESOURCE_GROUP_NAME --node-provisioning-mode Auto --network-plugin azure --network-plugin-mode overlay --network-dataplane cilium --generate-ssh-keys --location $LOCATION
+az aks create --name $CLUSTER_NAME --resource-group $RESOURCE_GROUP_NAME --node-resource-group "rg-${CLUSTER_NAME}-nodes" --node-provisioning-mode Auto --network-plugin azure --network-plugin-mode overlay --network-dataplane cilium --generate-ssh-keys --location $LOCATION
 
 # Create Nodepool with autoprovisioning
 

--- a/AKS-NodeRG-Lockdown/commands.sh
+++ b/AKS-NodeRG-Lockdown/commands.sh
@@ -47,7 +47,7 @@ az group create --name $RESOURCE_GROUP_NAME --location $LOCATION
 # Create a AKS Cluster without Node Resource Group lockdown
 
 echo "Creating AKS Cluster with default Node Resource Group"
-az aks create --name "$CLUSTER_NAME" --location $LOCATION --resource-group $RESOURCE_GROUP_NAME --generate-ssh-keys
+az aks create --name "$CLUSTER_NAME" --location $LOCATION --resource-group $RESOURCE_GROUP_NAME --node-resource-group "rg-${CLUSTER_NAME}-nodes" --generate-ssh-keys
 
 echo "Sleeping for 60 seconds to allow the cluster to be created"
 sleep 60
@@ -55,4 +55,4 @@ sleep 60
 # Create a AKS cluster with Node Resource Group Lockdown
 
 echo "Creating AKS Cluster with Node Resource Group Lockdown"
-az aks create --name "$CLUSTER_NAME-lockdown" --location $LOCATION --resource-group $RESOURCE_GROUP_NAME --nrg-lockdown-restriction-level ReadOnly --generate-ssh-keys
+az aks create --name "$CLUSTER_NAME-lockdown" --location $LOCATION --resource-group $RESOURCE_GROUP_NAME --node-resource-group "rg-${CLUSTER_NAME}-lockdown-nodes" --nrg-lockdown-restriction-level ReadOnly --generate-ssh-keys

--- a/Agentic-CLI-AKS/main.bicep
+++ b/Agentic-CLI-AKS/main.bicep
@@ -99,7 +99,7 @@ module aks 'modules/aks.bicep' = {
     clusterName: aksClusterName
     location: location
     kubernetesVersion: kubernetesVersion
-    nodeResourceGroupName: 'rg-${namePrefix}-${environment}-nodes'
+    nodeResourceGroupName: 'rg-${namePrefix}-${environment}-${uniqueSuffix}-nodes'
     nodeCount: nodeCount
     nodeVmSize: nodeVmSize
     subnetId: vnet.outputs.aksSubnetId

--- a/Agentic-CLI-AKS/main.bicep
+++ b/Agentic-CLI-AKS/main.bicep
@@ -99,6 +99,7 @@ module aks 'modules/aks.bicep' = {
     clusterName: aksClusterName
     location: location
     kubernetesVersion: kubernetesVersion
+    nodeResourceGroupName: 'rg-${namePrefix}-${environment}-nodes'
     nodeCount: nodeCount
     nodeVmSize: nodeVmSize
     subnetId: vnet.outputs.aksSubnetId

--- a/Agentic-CLI-AKS/modules/aks.bicep
+++ b/Agentic-CLI-AKS/modules/aks.bicep
@@ -24,6 +24,9 @@ param logAnalyticsWorkspaceId string
 @description('Enable monitoring')
 param enableMonitoring bool
 
+@description('Custom node resource group name')
+param nodeResourceGroupName string
+
 @description('Tags for the cluster')
 param tags object
 
@@ -38,6 +41,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-02-01' = {
   properties: {
     kubernetesVersion: kubernetesVersion
     dnsPrefix: clusterName
+    nodeResourceGroup: nodeResourceGroupName
     enableRBAC: true
     
     agentPoolProfiles: [

--- a/Azure-Copilot-AKS-Troubleshooting/main.bicep
+++ b/Azure-Copilot-AKS-Troubleshooting/main.bicep
@@ -50,6 +50,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
   }
   properties: {
     dnsPrefix: aksClusterName
+    nodeResourceGroup: 'rg-${aksClusterName}-nodes'
     kubernetesVersion: kubernetesVersion
     agentPoolProfiles: [
       {

--- a/BYO-CNI-AKS/main.bicep
+++ b/BYO-CNI-AKS/main.bicep
@@ -80,6 +80,7 @@ module aks 'modules/aks.bicep' = {
     clusterName: aksClusterName
     location: location
     kubernetesVersion: kubernetesVersion
+    nodeResourceGroupName: 'rg-${namePrefix}-${environment}-nodes'
     systemNodeCount: systemNodeCount
     systemNodeVmSize: systemNodeVmSize
     userNodeCount: userNodeCount

--- a/BYO-CNI-AKS/modules/aks.bicep
+++ b/BYO-CNI-AKS/modules/aks.bicep
@@ -31,6 +31,9 @@ param logAnalyticsWorkspaceId string
 @description('Enable monitoring')
 param enableMonitoring bool
 
+@description('Custom node resource group name')
+param nodeResourceGroupName string
+
 @description('Tags for the cluster')
 param tags object
 
@@ -45,6 +48,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-09-01' = {
   properties: {
     kubernetesVersion: kubernetesVersion
     dnsPrefix: clusterName
+    nodeResourceGroup: nodeResourceGroupName
     enableRBAC: true
 
     agentPoolProfiles: [


### PR DESCRIPTION
This pull request introduces a new AKS + Application Gateway for Containers (AGFC) demo, including comprehensive documentation, deployment, and cleanup scripts. The changes focus on providing a robust, end-to-end example for deploying AKS clusters with the next-generation Application Gateway, supporting both managed and bring-your-own (BYO) strategies. It also updates conventions for AKS node resource group naming and enforces best practices in Bicep deployments.

**Key changes include:**

### New Demo: AKS + Application Gateway for Containers

- Added a detailed `README.md` in `AKS-AppGW-Containers` that explains AGFC concepts, deployment strategies (managed vs. BYO), architecture diagrams, testing procedures, advanced Gateway API features (traffic splitting, SSL offloading, backend mTLS), troubleshooting, and important limitations. This serves as a comprehensive guide for users deploying AKS with AGFC.

- Introduced a new `cleanup.sh` script to automate the teardown of demo resources, including Kubernetes manifests and the Azure resource group, with user confirmation and clear output messaging.

### Infrastructure & Deployment Improvements

- Updated the main AKS Bicep module (`AKS-Advanced-Container-Networking/main.bicep`) to explicitly set the `nodeResourceGroup` property using a custom, readable naming convention, improving resource organization and clarity.

### Documentation & Conventions

- Added AKS node resource group naming conventions to `.github/copilot-instructions.md`, recommending always specifying a custom, readable `nodeResourceGroup` and providing a standard naming pattern for consistency across deployments.